### PR TITLE
Change the property names 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ row_cache_class_name: org.apache.cassandra.cache.CapiRowCacheProvider
 5. Specify the following property to the JVM. Usually, you specify it in Cassandra's conf/jvm.options file.
 
 ```
--Dcapi.devices=/dev/sg0:0:512
+-Dcom.ibm.capiflash.cassandra.cache.devices=/dev/sg0:0:512
 ```
 
 This means that your CAPI-Flash device is /dev/sg0, the start address of CAPI-RowCache is 0 in the flash address space, and the size of CAPI-RowCache is 512 GB. You can find the CAPI-Flash device on your POWER Linux machine by executing the /opt/ibm/capikv/bin/cxlfstatus command.
@@ -76,7 +76,7 @@ row_cache_class_name: org.apache.cassandra.cache.CapiRowCacheProvider
 3. Specify the following properties to the JVM. Usually, you specify them in Cassandra's conf/jvm.options file.
 
 ```
--Dcapi.devices=/path/to/your/capiflash/emulation/file.dat:0:10
+-Dcom.ibm.capiflash.cassandra.cache.devices=/path/to/your/capiflash/emulation/file.dat:0:10
 ```
 
 This means that you will use `/path/to/your/capiflash/emulation/file.dat` to emulate CAPI-Flash. You can specify any regular file. You may want to use a file on tmpfs or `/dev/shm`. `0` means CAPI-RowCache starts at offset 0 in the file, and `10` means CAPI-RowCache will use 10 GB in the file
@@ -91,7 +91,7 @@ This property enables the CAPI-Flash emulation.
 -Dcom.ibm.research.capiblock.capacity=2621440
 ```
 
-This property specifies the size (in 4-KB blocks) of the regular file used for the emulation. It must be larger than the offset plus the size specified in the `capi.devices` property. In this example, `2621440` is equal to 2621440 * 4 KB = 10 GB. Note that this means you will create a 10-GB file on your file system.
+This property specifies the size (in 4-KB blocks) of the regular file used for the emulation. It must be larger than the offset plus the size specified in the `com.ibm.capiflash.cassandra.cache.devices` property. In this example, `2621440` is equal to 2621440 * 4 KB = 10 GB. Note that this means you will create a 10-GB file on your file system.
 
 4. (Optional) If you run [Yahoo! Cloud Serving (System) Benchmark](https://github.com/brianfrankcooper/YCSB) to test CAPI-RowCache, you may want to specify the following property to the JVM for better caching behavior.
 

--- a/src/org/apache/cassandra/cache/CapiRowCacheProvider.java
+++ b/src/org/apache/cassandra/cache/CapiRowCacheProvider.java
@@ -30,7 +30,7 @@ public class CapiRowCacheProvider implements org.apache.cassandra.cache.CachePro
 
     public static final int DEFAULT_L2CACHE = 128 * 1024 * 1024;
     public static final int DEFAULT_CONCURENCY_LEVEL = 64;
-    public static final String PROP_CAPI_DEVICE_NAMES = "capi.devices";
+    public static final String PROP_CAPI_DEVICE_NAMES = "com.ibm.capiflash.cassandra.cache.devices";
     public static final long DEFAULT_SIZE_IN_GB_BYTES = 1L; // 1 gb
 
     public static AtomicLong touched = new AtomicLong();
@@ -74,7 +74,7 @@ public class CapiRowCacheProvider implements org.apache.cassandra.cache.CachePro
                 }
             }).maximumWeightedCapacity(DEFAULT_L2CACHE).concurrencyLevel(DEFAULT_CONCURENCY_LEVEL).build();
 
-            String hashClass = System.getProperty("capi.hash");
+            String hashClass = System.getProperty("com.ibm.capiflash.cassandra.cache.hash");
             try {
                 hashFunc = hashClass == null ? new HashFunction() {
                     public int hashCode(byte[] key) {
@@ -90,8 +90,8 @@ public class CapiRowCacheProvider implements org.apache.cassandra.cache.CachePro
             }
 
             int blocksize = CapiBlockDevice.BLOCK_SIZE;
-            int numOfAsync = Integer.parseInt(System.getProperty("capi.async", "64"));
-            int numOfDriver = Integer.parseInt(System.getProperty("capi.driver", "32"));
+            int numOfAsync = Integer.parseInt(System.getProperty("com.ibm.capiflash.cassandra.cache.async", "64"));
+            int numOfDriver = Integer.parseInt(System.getProperty("com.ibm.capiflash.cassandra.cache.driver", "32"));
 
             String deviceNamesStr = System.getProperty(PROP_CAPI_DEVICE_NAMES);
             if (deviceNamesStr == null) {
@@ -101,7 +101,7 @@ public class CapiRowCacheProvider implements org.apache.cassandra.cache.CachePro
 
             this.sm = new SimpleCapiSpaceManager();
 
-            // -Dcapi.devices=/dev/sg7:<OFFSET>:<GB_SIZE>:/dev/sg7:/dev/sg8:/dev/sg8,/dev/sdc:<OFFSET>:<GB_SIZE>
+            // -Dcom.ibm.capiflash.cassandra.cache.devices=/dev/sg7:<OFFSET>:<GB_SIZE>:/dev/sg7:/dev/sg8:/dev/sg8,/dev/sdc:<OFFSET>:<GB_SIZE>
             String[] deviceInfos = deviceNamesStr.split(",");
 
             StringBuffer storageArea = new StringBuffer();

--- a/src/org/apache/cassandra/cache/capi/CapiChunkDriver.java
+++ b/src/org/apache/cassandra/cache/capi/CapiChunkDriver.java
@@ -29,13 +29,13 @@ public class CapiChunkDriver {
     public static AtomicLong executed = new AtomicLong();
     public static AtomicLong totalElapsed = new AtomicLong();
 
-    public static boolean pooled = System.getProperty("capi.driver.task.nopool") == null;
-    public static int numOfMaxThreads = Integer.parseInt(System.getProperty("capi.driver.thread.max", "32"));
-    public static int numOfMinThreads = Integer.parseInt(System.getProperty("capi.driver.thread.min", "16"));
-    public static int numOfQueue = Integer.parseInt(System.getProperty("capi.driver.queue", "4"));
-    public static int FLUSH_QUEUE_MAX_DEPTH = Integer.parseInt(System.getProperty("capi.driver.queue.max", "10000"));
+    public static boolean pooled = System.getProperty("com.ibm.capiflash.cassandra.cache.driver.task.nopool") == null;
+    public static int numOfMaxThreads = Integer.parseInt(System.getProperty("com.ibm.capiflash.cassandra.cache.driver.thread.max", "32"));
+    public static int numOfMinThreads = Integer.parseInt(System.getProperty("com.ibm.capiflash.cassandra.cache.driver.thread.min", "16"));
+    public static int numOfQueue = Integer.parseInt(System.getProperty("com.ibm.capiflash.cassandra.cache.driver.queue", "4"));
+    public static int FLUSH_QUEUE_MAX_DEPTH = Integer.parseInt(System.getProperty("com.ibm.capiflash.cassandra.cache.driver.queue.max", "10000"));
 
-    public static boolean polling = System.getProperty("capi.driver.thread.polling") != null;
+    public static boolean polling = System.getProperty("com.ibm.capiflash.cassandra.cache.driver.thread.polling") != null;
 
     public static int getAlignedSize(int size) {
         return getLBASize(size) * CapiBlockDevice.BLOCK_SIZE;


### PR DESCRIPTION
From 'capi.*' to 'com.ibm.capiflash.cassandra.cache.*', to avoid conflicts.